### PR TITLE
[Next.js 스터디] codegen.yml headers 추가

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,8 +1,8 @@
 overwrite: true
 schema:
-  - ${NEXT_PUBLIC_API_ENDPOINT}
-    headers:
-      authorization: "realnextjsworld"
+  - ${NEXT_PUBLIC_API_ENDPOINT}:
+      headers:
+      Authorization: "TEST"
 documents: "src/lib/graphql/**/*.graphql"
 generates:
   src/lib/graphql/generated.tsx:


### PR DESCRIPTION
headers 추가할 때 형식을 아래처럼 써야 오류가 안남
indent가 영향을 미친다^^;

```typescript
schema:
  - ${NEXT_PUBLIC_API_ENDPOINT}:
      headers:
      Authorization: "TEST"
```